### PR TITLE
Updated Learning Workflow to work after name changes

### DIFF
--- a/cluster_tools/learning/edge_labels.py
+++ b/cluster_tools/learning/edge_labels.py
@@ -24,8 +24,8 @@ class EdgeLabelsBase(luigi.Task):
     allow_retry = False
 
     # input and output volumes
-    overlap_path = luigi.Parameter()
-    overlap_key = luigi.Parameter()
+    node_labels_path = luigi.Parameter()
+    node_labels_key = luigi.Parameter()
     graph_path = luigi.Parameter()
     graph_key = luigi.Parameter()
     output_path = luigi.Parameter()
@@ -51,7 +51,7 @@ class EdgeLabelsBase(luigi.Task):
         config = self.get_task_config()
 
         # update the task config
-        config.update({'overlap_path': self.overlap_path, 'overlap_key': self.overlap_key,
+        config.update({'node_labels_path': self.node_labels_path, 'node_labels_key': self.node_labels_key,
                        'output_path': self.output_path, 'output_key': self.output_key,
                        'graph_path': self.graph_path, 'graph_key': self.graph_key})
 
@@ -99,13 +99,13 @@ def edge_labels(job_id, config_path):
     output_key = config['output_key']
     graph_path = config['graph_path']
     graph_key = config['graph_key']
-    overlap_path = config['overlap_path']
-    overlap_key = config['overlap_key']
+    node_labels_path = config['node_labels_path']
+    node_labels_key = config['node_labels_key']
     ignore_label_gt = config.get('ignore_label_gt', False)
 
-    # load the node overlaps
-    with vu.file_reader(overlap_path, 'r') as f:
-        node_labels = f[overlap_key][:]
+    # load the node labels
+    with vu.file_reader(node_labels_path, 'r') as f:
+        node_labels = f[node_labels_key][:]
 
     # load the uv ids and check
     with vu.file_reader(graph_path, 'r') as f:

--- a/cluster_tools/learning/learning_workflow.py
+++ b/cluster_tools/learning/learning_workflow.py
@@ -6,7 +6,7 @@ from ..cluster_tasks import WorkflowBase
 # TODO Region features
 from ..features import EdgeFeaturesWorkflow
 from ..graph import GraphWorkflow
-from ..node_overlaps import NodeOverlapWorkflow
+from ..node_labels import NodeLabelWorkflow
 from . import edge_labels as label_tasks
 from . import learn_rf as learn_tasks
 
@@ -50,6 +50,7 @@ class LearningWorkflow(WorkflowBase):
                                        input_path=labels_path[0],
                                        input_key=labels_path[1],
                                        graph_path=graph_out,
+                                       output_key='graph',
                                        n_scales=n_scales)
 
             features_out = os.path.join(tmp_folder, 'features.n5')
@@ -68,18 +69,18 @@ class LearningWorkflow(WorkflowBase):
                                              output_key='features')
             features_dict[key] = (features_out, 'features')
 
-            ovlp_out = os.path.join(tmp_folder, 'gt_overlaps.n5')
-            ovlp_task = NodeOverlapWorkflow(tmp_folder=tmp_folder,
+            node_labels_out = os.path.join(tmp_folder, 'gt_node_labels.n5')
+            node_labels_task = NodeLabelWorkflow(tmp_folder=tmp_folder,
                                             max_jobs=self.max_jobs,
                                             config_dir=self.config_dir,
                                             target=self.target,
                                             dependency=feat_task,
-                                            labels_path=labels_path[0],
-                                            labels_key=labels_path[1],
+                                            ws_path=labels_path[0],
+                                            ws_key=labels_path[1],
                                             input_path=gt_path[0],
                                             input_key=gt_path[1],
-                                            output_path=ovlp_out,
-                                            output_key='overlaps')
+                                            output_path=node_labels_out,
+                                            output_key='node_labels')
 
             edge_labels_out = os.path.join(tmp_folder, 'edge_labels.n5')
             lt = getattr(label_tasks,
@@ -87,11 +88,11 @@ class LearningWorkflow(WorkflowBase):
             label_task = lt(tmp_folder=tmp_folder,
                             max_jobs=self.max_jobs,
                             config_dir=self.config_dir,
-                            dependency=ovlp_task,
+                            dependency=node_labels_task,
                             graph_path=graph_out,
                             graph_key='graph',
-                            overlap_path=ovlp_out,
-                            overlap_key='overlaps',
+                            overlap_path=node_labels_out,
+                            overlap_key='node_labels',
                             output_path=edge_labels_out,
                             output_key='edge_labels')
             prev_dep = label_task

--- a/cluster_tools/learning/learning_workflow.py
+++ b/cluster_tools/learning/learning_workflow.py
@@ -91,8 +91,8 @@ class LearningWorkflow(WorkflowBase):
                             dependency=node_labels_task,
                             graph_path=graph_out,
                             graph_key='graph',
-                            overlap_path=node_labels_out,
-                            overlap_key='node_labels',
+                            node_labels_path=node_labels_out,
+                            node_labels_key='node_labels',
                             output_path=edge_labels_out,
                             output_key='edge_labels')
             prev_dep = label_task


### PR DESCRIPTION
Fixed the learning workflow which no longer worked after "NodeOverlap" was changed to "NodeLabels" and also changed some parameter names to be consistent with that change of terminology.