### PR TITLE
Update copy_volume.py

### DIFF
--- a/cluster_tools/copy_volume/copy_volume.py
+++ b/cluster_tools/copy_volume/copy_volume.py
@@ -125,7 +125,7 @@ class CopyVolumeBase(luigi.Task):
         dtype = DTYPE_MAPPING.get(dtype, dtype)
         if self.int_to_uint:
             assert np.issubdtype(dtype, np.signedinteger), f"Expect a signed integer type, got {dtype}"
-            dtype = "u" + dtype
+            dtype = "u" + str(dtype)
 
         chunks = task_config.pop("chunks", None)
         chunks = tuple(block_shape) if chunks is None else chunks


### PR DESCRIPTION
needs to be converted to `str`, otherwise if is determined from data, it will fail with:

```
    dtype = "u" + dtype
TypeError: can only concatenate str (not "numpy.dtype[int8]") to str
```

see https://github.com/mobie/mobie-utils-python/pull/57