### PR TITLE
implement metadata checks for downscaling

### DIFF
--- a/cluster_tools/downscaling/downscaling.py
+++ b/cluster_tools/downscaling/downscaling.py
@@ -351,7 +351,7 @@ def downscaling(job_id, config_path):
     with open(config_path, "r") as f:
         config = json.load(f)
 
-    # read the input cofig
+    # read the input config
     input_path = config["input_path"]
     input_key = config["input_key"]
 

--- a/cluster_tools/downscaling/downscaling_workflow.py
+++ b/cluster_tools/downscaling/downscaling_workflow.py
@@ -74,6 +74,10 @@ class DownscalingWorkflow(WorkflowBase):
         assert all(len(halo) == ndim for halo in halos if halo)
         return halos
 
+    @staticmethod
+    def validate_resolution(metadata_dict):
+        return metadata_dict
+
     def _is_h5(self):
         h5_exts = (".h5", ".hdf5", ".hdf")
         out_path = self.input_path if self.output_path == "" else self.output_path

--- a/cluster_tools/downscaling/downscaling_workflow.py
+++ b/cluster_tools/downscaling/downscaling_workflow.py
@@ -86,9 +86,10 @@ class DownscalingWorkflow(WorkflowBase):
             resolution[idx] = float(pxs)
             assert resolution[idx] > 0
 
-        metadata_dict["resolution"] = resolution
-
-        return metadata_dict
+        tmp_dict = dict(metadata_dict)
+        tmp_dict["resolution"] = resolution
+        out_dict = luigi.freezing.recursively_freeze(tmp_dict)
+        return out_dict
 
     def _is_h5(self):
         h5_exts = (".h5", ".hdf5", ".hdf")

--- a/cluster_tools/downscaling/downscaling_workflow.py
+++ b/cluster_tools/downscaling/downscaling_workflow.py
@@ -75,7 +75,19 @@ class DownscalingWorkflow(WorkflowBase):
         return halos
 
     @staticmethod
-    def validate_resolution(metadata_dict):
+    def validate_resolution(metadata_dict, ndim=3):
+        resolution = metadata_dict["resolution"]
+        assert isinstance(resolution, (list, tuple))
+        resolution = list(resolution)
+        assert len(resolution) == ndim
+
+        for idx, pxs in enumerate(resolution):
+            assert isinstance(pxs, (str, int, float))
+            resolution[idx] = float(pxs)
+            assert resolution[idx] > 0
+
+        metadata_dict["resolution"] = resolution
+
         return metadata_dict
 
     def _is_h5(self):
@@ -169,6 +181,7 @@ class DownscalingWorkflow(WorkflowBase):
         self.validate_scale_factors(self.scale_factors, self.metadata_format)
         ndim = len(self.scale_factors[0])
         halos = self.validate_halos(self.halos, len(self.scale_factors), ndim)
+        self.metadata_dict = self.validate_resolution(self.metadata_dict, ndim)
         self.validate_format()
 
         out_path = self.input_path if self.output_path == "" else self.output_path

--- a/cluster_tools/downscaling/downscaling_workflow.py
+++ b/cluster_tools/downscaling/downscaling_workflow.py
@@ -76,6 +76,9 @@ class DownscalingWorkflow(WorkflowBase):
 
     @staticmethod
     def validate_resolution(metadata_dict, ndim=3):
+        if "resolution" not in metadata_dict.keys():
+            return metadata_dict
+
         resolution = metadata_dict["resolution"]
         assert isinstance(resolution, (list, tuple))
         resolution = list(resolution)

--- a/test/downscaling/test_downscaling.py
+++ b/test/downscaling/test_downscaling.py
@@ -118,7 +118,7 @@ class TestDownscaling(BaseTest):
             data = ds[:]
             self.assertFalse(np.allclose(data, 0))
 
-    def _downscale(self, metadata_format, int_to_uint=False):
+    def _downscale(self, metadata_format, metadata_dict={}, int_to_uint=False):
         from cluster_tools.downscaling import DownscalingWorkflow
         task = DownscalingWorkflow
 
@@ -150,6 +150,7 @@ class TestDownscaling(BaseTest):
                  config_dir=self.config_folder, tmp_folder=self.tmp_folder,
                  target=self.target, max_jobs=max_jobs,
                  metadata_format=metadata_format,
+                 metadata_dict=metadata_dict,
                  int_to_uint=int_to_uint)
 
         ret = luigi.build([t], local_scheduler=True)
@@ -185,6 +186,10 @@ class TestDownscaling(BaseTest):
         shape = z5py.File(self.input_path)[self.input_key].shape
         scales = [[1, 1, 1]] + scales
         self.check_result_bdv_n5(shape, scales, int_to_uint=True)
+
+    def test_resolution_metadata(self):
+        pass
+
 
 
 if __name__ == "__main__":

--- a/test/downscaling/test_downscaling.py
+++ b/test/downscaling/test_downscaling.py
@@ -188,7 +188,22 @@ class TestDownscaling(BaseTest):
         self.check_result_bdv_n5(shape, scales, int_to_uint=True)
 
     def test_resolution_metadata(self):
-        pass
+        # metadata_dict = {"resolution": resolution, "unit": unit, "setup_name": source_name}
+
+        for wrong_res in [1, [], [1,2], ('4'), [1,2,-3], [0,1,2], ('1', '2.0', 'non_numeric_string')]:
+            wrong_metadata = {"resolution": wrong_res, "unit": "lightyears", "setup_name": "image1"}
+            with self.assertRaises(AssertionError):
+                __ = self._downscale(metadata_format="ome.zarr", metadata_dict=wrong_metadata)
+
+        res2 =(1, 2.0, '3.1415')
+        good_metadata = {"resolution": res2, "unit": "lightyears", "setup_name": "image1"}
+
+        scales = self._downscale(metadata_format="ome.zarr", metadata_dict=good_metadata)
+        shape = z5py.File(self.input_path)[self.input_key].shape
+        scales = [[1, 1, 1]] + scales
+        self.check_result_ome_zarr(shape, scales)
+
+#         TODO: check metadata
 
 
 


### PR DESCRIPTION
type checks to fix
https://github.com/mobie/mobie-utils-python/issues/135

and sanity checks to validate the written result's metadata is consistent with the input parameters.

So far supports only OME-Zarr.

Do we need these checks for N5 as well?