### PR TITLE
Avoid deprecated scipy.ndimage sub-namespaces

### DIFF
--- a/cluster_tools/morphology/region_centers.py
+++ b/cluster_tools/morphology/region_centers.py
@@ -10,7 +10,7 @@ import json
 import numpy as np
 import luigi
 import nifty.tools as nt
-from scipy.ndimage.morphology import distance_transform_edt
+from scipy.ndimage import distance_transform_edt
 
 import cluster_tools.utils.volume_utils as vu
 import cluster_tools.utils.function_utils as fu

--- a/cluster_tools/utils/volume_utils.py
+++ b/cluster_tools/utils/volume_utils.py
@@ -8,7 +8,7 @@ import vigra
 import z5py
 
 from elf.wrapper.resized_volume import ResizedVolume
-from scipy.ndimage.morphology import binary_erosion
+from scipy.ndimage import binary_erosion
 from nifty.tools import blocking
 from pybdv.metadata import (write_h5_metadata,
                             write_n5_metadata,


### PR DESCRIPTION
See https://docs.scipy.org/doc/scipy/release/1.8.0-notes.html#clear-split-between-public-and-private-api.